### PR TITLE
fix(ahs.el): Fix stringp error eval ahs-stat-string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 * introduce new variable `ahs-enable-focus-hooks' to enable/disable focus hooks
 * Fixed not clearing highlight issue when moving the whole symbol
 * Fixed highlighting when before/after insertion hooks.
+* Fix stringp error eval ahs-stat-string (#20)
 
 ## v1.61
 > Released Jul 9, 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## v1.62 (Unreleased)
 > Released N/A
 
-* introduce new variable `ahs-highlight-upon-window-switch' to adapte old behaviour
-* introduce new variable `ahs-highlight-all-windows' to adapte old behaviour
-* introduce new variable `ahs-enable-focus-hooks' to enable/disable focus hooks
+* introduce new variable `ahs-highlight-upon-window-switch' to adapte old behaviour (#15)
+* introduce new variable `ahs-highlight-all-windows' to adapte old behaviour (#14)
+* introduce new variable `ahs-enable-focus-hooks' to enable/disable focus hooks (#17)
 * Fixed not clearing highlight issue when moving the whole symbol
 * Fixed highlighting when before/after insertion hooks.
 * Fix stringp error eval ahs-stat-string (#20)

--- a/auto-highlight-symbol.el
+++ b/auto-highlight-symbol.el
@@ -1200,7 +1200,7 @@ You can do these operations at One Key!
     (overlay-put overlay 'ahs-symbol 'current)
     (overlay-put overlay 'priority ahs-overlay-priority)
     (overlay-put overlay 'face face)
-    (overlay-put overlay 'help-echo '(ahs-stat-string))
+    (overlay-put overlay 'help-echo '(or (ignore-errors (ahs-stat-string)) ""))
     (overlay-put overlay 'window (selected-window))
 
     (overlay-put overlay 'modification-hooks    '(ahs-modification-hook))


### PR DESCRIPTION
Fix the following error when using the mouse to hover the symbol.

```
Error during redisplay: (eval (ahs-stat-string)) signaled (wrong-type-argument stringp none)
```