### PR TITLE
adds setup information to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@
 
 [![CI](https://github.com/jcs-elpa/auto-highlight-symbol/actions/workflows/test.yml/badge.svg)](https://github.com/jcs-elpa/auto-highlight-symbol/actions/workflows/test.yml)
 
+## Setup
+
+1. Place `auto-highlight-symbol.el` in your `load-path`.
+2. Add these two lines to your `.emacs.el` file
+```
+(require 'auto-highlight-symbol)
+(global-auto-highlight-symbol-mode t)
+```
+
 ## Author
 
 * **Original Author:** 


### PR DESCRIPTION
Thank you for developing this minor mode. It's quite useful for me.

As a novice emacs user, it was hard for me to notice the configuration I should use in the comments section. It would be better for new users like me to have this in `README.md`.

It can be further improved by adding screenshots, key binding, etc.

PS: I didn't delete them but the screencast links in the `auto-highlight-symbol.el`  are all broken.